### PR TITLE
fix: Allow empty input when editing account

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -89,8 +89,8 @@ def edit_account():
         return
 
     print(f"\n--- Editing Account: {acc['name']} ---")
-    new_name = get_validated_input(f"Enter new name (or press Enter to keep '{acc['name']}'): ", lambda s: s.strip(), allow_empty=True)
-    new_token = get_validated_input("Enter new API token (or press Enter to keep current): ", lambda s: s.strip(), allow_empty=True)
+    new_name = get_validated_input(f"Enter new name (or press Enter to keep '{acc['name']}'): ", lambda s: s.strip(), "Invalid input.", allow_empty=True)
+    new_token = get_validated_input("Enter new API token (or press Enter to keep current): ", lambda s: s.strip(), "Invalid input.", allow_empty=True)
 
     if new_name or new_token:
         edit_account_in_config(acc['name'], new_name, new_token)

--- a/src/input_helper.py
+++ b/src/input_helper.py
@@ -1,13 +1,16 @@
 from .validator import is_valid_ipv4, is_valid_ipv6
 from .logger import logger
 
-def get_validated_input(prompt, validation_func, error_message):
+def get_validated_input(prompt, validation_func, error_message, allow_empty=False):
     """
     Prompts the user for input and validates it using the provided validation function.
     If validation fails, it prints the error message and retries.
     """
     while True:
         user_input = input(prompt).strip()
+        if allow_empty and user_input == "":
+            return user_input
+            
         if validation_func(user_input):
             return user_input
         else:


### PR DESCRIPTION
## Summary  
This PR fixes a `TypeError` when editing an account due to a mismatch between the function call and signature of `get_validated_input`.

## Changes  
- **`get_validated_input`** (in `src/input_helper.py`):  
  - Added a new `allow_empty` parameter to the function signature.  
  - Updated internal logic to correctly handle cases where empty input is allowed.  

- **`src/app.py`**:  
  - Added missing `error_message` argument in calls to `get_validated_input`.  

## Motivation  
Previously, when editing an account, the CLI passed an `allow_empty` argument to `get_validated_input`, but the function signature did not define it, causing a `TypeError`. This fix ensures compatibility and improves flexibility when empty input is a valid option.

## Testing  
- Verified that editing an account with empty input no longer raises a `TypeError`.  
- Confirmed that validation and error messages still work as expected for non-empty input cases.

## Related Issues  
Closes #<issue_number> (if applicable)
